### PR TITLE
pin github action version hashes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
-        uses: actions/checkout@4ffde65f46336ab88eb53be808477a3936bae11  # v4.1.1
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4.1.1
       - name: Setup Docker buildx
         uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb  # v3.3.0
       - name: Cache Docker layers

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,15 +14,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
-        uses: actions/checkout@v4.1.3
+        uses: actions/checkout@1e31de5234b9f8995739874a8ce0492dc87873e2  # v4.0.0
         with:
           persist-credentials: false
       - name: Setup Python
-        uses: actions/setup-python@v5.1.0
+        uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d  # v5.1.0
         with:
           python-version: '3.12.0'
       - name: Run pre-commit
-        uses: pre-commit/action@v3.0.1
+        uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd  # v3.0.1
         with:
           extra_args: --all-files --show-diff-on-failure --color always
         env:
@@ -39,11 +39,11 @@ jobs:
 
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
-        uses: actions/checkout@v4.1.3
+        uses: actions/checkout@4ffde65f46336ab88eb53be808477a3936bae11  # v4.1.1
       - name: Setup Docker buildx
-        uses: docker/setup-buildx-action@v3.3.0
+        uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb  # v3.3.0
       - name: Cache Docker layers
-        uses: docker/bake-action@v4.3.0
+        uses: docker/bake-action@017aa056d6bfc9797de5a5dd354a209dc07b490e  # v4.3.0
         with:
           targets: |
             tests
@@ -56,14 +56,14 @@ jobs:
         run: |
           docker compose run tests --junitxml=reports/junit.xml --cov=. --cov-branch --cov-report=term --cov-report=xml:reports/coverage.xml --cov-report=html:reports/coverage
       - name: Test Report
-        uses: dorny/test-reporter@v1.9.0
+        uses: dorny/test-reporter@c40d89d5e987cd80f3a32b3c233556e22bdca958  # v1.9.0
         if: success() || failure()
         with:
           name: pytest results
           path: reports/junit.xml
           reporter: java-junit
       - name: Code Coverage Report
-        uses: irongut/CodeCoverageSummary@v1.3.0
+        uses: irongut/CodeCoverageSummary@51cc3a756ddcd398d447c044c02cb6aa83fdae95  # v1.3.0
         with:
           filename: reports/coverage.xml
           badge: true
@@ -75,7 +75,7 @@ jobs:
           output: both
           thresholds: '80 90'
       - name: Add Coverage PR Comment
-        uses: marocchino/sticky-pull-request-comment@v2.9.0
+        uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31  # v2.9.0
         if: github.event_name == 'pull_request'
         with:
           recreate: true


### PR DESCRIPTION
Pinned the GHA version hashes to protect against supply chain attack.
Source: https://blog.rafaelgss.dev/why-you-should-pin-actions-by-commit-hash

I intentionally left one version downgraded to make sure this works.